### PR TITLE
Generate ATOM feed for posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "jekyll-include-cache"
 gem "jekyll-paginate"
 
 gem "jekyll-analytics"
+
+gem "jekyll-feed"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-analytics
+  jekyll-feed
   jekyll-include-cache
   jekyll-paginate
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ plugins:
   - jekyll-include-cache
   - jekyll-paginate
   - jekyll-analytics
+  - jekyll-feed
 remote_theme: "mmistakes/minimal-mistakes@4.19.3"
 minimal_mistakes_skin: "air"
 markdown: kramdown


### PR DESCRIPTION
I wanted to add your blog to my feed reader, but it complained feed couldn't be found. Turns out that while your HTML contains link to Atom feed (`<link href="/feed.xml" type="application/atom+xml" rel="alternate" title="On Test Automation Feed">`), that file is not generated and not present on live website.

Took a moment to fix it :) 

My local `Gemfile.lock` has more changes, but they don't seem in any way related to feeds plugin, so I'm not committing them. Let me know if you would like me to include them anyway.